### PR TITLE
Fix WSL compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -15,6 +15,7 @@ for inc in \
     /usr/X11R5/include        \
     /usr/X11R4/include        \
                               \
+    /usr/include              \
     /usr/include/X11          \
     /usr/include/X11R6        \
     /usr/include/X11R5        \


### PR DESCRIPTION
This short line in configure, will add support to the Windows Subsystem for Linux (WSL)
The search path for the manually installed X11 was not included