### PR TITLE
Update README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Requirements
 
  - MinilibX only support TrueColor visual type (8,15,16,24 or 32 bits depth)
  - gcc
- - X11 include files
- - XShm extension must be present
-
-
+ - make
+ - X11 include files (package xorg)
+ - XShm extension must be present (package libxext-dev)
+ - Utility functions from BSD systems - development files (package libbsd-dev)
+ - **e.g. _sudo apt-get install gcc make xorg libxext-dev libbsd-dev_ (Debian/Ubuntu)**
+ 
 Compile MinilibX
 
  - run ./configure or make


### PR DESCRIPTION
Adding the necessary context for Linux installation 

Issue: /usr/bin/ld: cannot find -lbsd
This command requires BSD libraries, which can be found in package libbsd-dev.

XShm extension >>  /usr/include/X11/extensions/XShm.h
[](https://packages.debian.org/search?suite=sid&section=all&arch=any&searchon=contents&keywords=XShm.h) Which can be found in package libxext-dev

gcc -o mlx-test main.o -L.. -lmlx -L/usr/include/../lib -lXext -lX11 -lm -lbsd
/usr/bin/ld: cannot find -lbsd