### PR TITLE
GCC 10 update & screensync

### DIFF
--- a/mlx_int.h
+++ b/mlx_int.h
@@ -131,7 +131,6 @@ void			*mlx_new_image();
 int				shm_att_pb();
 int				mlx_int_get_visual(t_xvar *xvar);
 int				mlx_int_set_win_event_mask(t_xvar *xvar);
-int				(*(mlx_int_param_event[37]))();
 int				mlx_int_str_str_cote(char *str,char *find,int len);
 int				mlx_int_str_str(char *str,char *find,int len);
 

--- a/mlx_loop.c
+++ b/mlx_loop.c
@@ -37,6 +37,7 @@ int		mlx_loop(t_xvar *xvar)
 					mlx_int_param_event[ev.type](xvar, &ev, win);
 			}
 		}
+		XSync(xvar->display, False);
 		xvar->loop_hook(xvar->loop_param);
 	}
 }


### PR DESCRIPTION
As of GCC 10, it now compiles using the flag -fno-common which throws error when variables are defined multiple times. Since mlx_int_param_event was definied in mlx_int.h and that header guard does not protect from multiple variable definition, it would get defined in ever file invoking mlx_int.h. Removing it from mlx_int.h does not create any issue as the only file using the variable from another file already includes an extern definition to it.

The other modification is to add a XSync after the loop managing event. This is to avoid starting the loop_hook before all events have been handled.
Most classic case would be that we edit an image in the loop_hook function while one of the even is still trying to print it onto the screen, causing splitting or flashing (and possibly other artifacts).