### PR TITLE
Clean way to quit 

### DIFF
--- a/mlx_loop.c
+++ b/mlx_loop.c
@@ -13,16 +13,34 @@
 
 extern int	(*(mlx_int_param_event[]))();
 
-
-int		mlx_loop(t_xvar *xvar)
+static int	win_count(t_xvar *xvar)
 {
+	int			i;
+	t_win_list	*win;
+
+	i = 0;
+	win = xvar->win_list;
+	while (win)
+	{
+		win = win->next;
+		++i;
+	}
+	return (i);
+}
+
+int			mlx_destroy_window(t_xvar *xvar,t_win_list *win);
+
+int			mlx_loop(t_xvar *xvar)
+{
+	int			pass;
 	XEvent		ev;
 	t_win_list	*win;
 
 	mlx_int_set_win_event_mask(xvar);
 	xvar->do_flush = 0;
-	while (42)
+	while (win_count(xvar))
 	{
+		pass = 0;
 		while (!xvar->loop_hook || XPending(xvar->display))
 		{
 			XNextEvent(xvar->display,&ev);
@@ -32,12 +50,19 @@ int		mlx_loop(t_xvar *xvar)
 			if (win && ev.type < MLX_MAX_EVENT)
 			{
 				if (ev.type == ClientMessage && (Atom)ev.xclient.data.l[0] == xvar->wm_delete_window)
-					XDestroyWindow(xvar->display, win->window);
+				{
+					mlx_destroy_window(xvar, win);
+					pass = 1;
+					break ;
+				}
 				if (win->hooks[ev.type].hook)
 					mlx_int_param_event[ev.type](xvar, &ev, win);
 			}
 		}
+		if (pass)
+			continue ;
 		XSync(xvar->display, False);
 		xvar->loop_hook(xvar->loop_param);
 	}
+	return (0);
 }


### PR DESCRIPTION
~Fix `mlx_destroy_dispaly` instead of `mlx_destroy_display` in `mlx.h` file.~

Window is fully destroyed (trough `mlx_destroy_window`) so everything's freed properly.
Loop stops once all windows has been closed.
This allows the user to get the code execution back after the `mlx_loop` call, clean all allocated memory and quit the program by returning in the main function.

This quick example show how it could be used.
```C
void *x;
void *window;

int close_window()
{
	mlx_destroy_window(x, window);
	window = NULL;
}

int loop(void *ptr)
{
	if (window)
	{
		// do your rendering stuff here
	}
}

void	main(void)
{
	x = mlx_init();
	window = mlx_new_window(x, 800, 600, "Test");
	mlx_loop_hook(x, loop, NULL);

	mlx_loop(x);

	mlx_destroy_display(x);
	free(x);
 	return (0);
}
```
The programmer can simply call `close_window` to properly stop the loop and get back to the main function, allowing him to destroy the display and free the xvar pointer before returning clean from `main`