### PR TITLE
add mlx_loop_end

### DIFF
--- a/mlx.h
+++ b/mlx.h
@@ -87,7 +87,7 @@ int	mlx_expose_hook (void *win_ptr, int (*funct_ptr)(), void *param);
 
 int	mlx_loop_hook (void *mlx_ptr, int (*funct_ptr)(), void *param);
 int	mlx_loop (void *mlx_ptr);
-
+int mlx_loop_end (void *mlx_ptr);
 
 /*
 **  hook funct are called as follow :

--- a/mlx_init.c
+++ b/mlx_init.c
@@ -43,6 +43,7 @@ void	*mlx_init()
 		xvar->cmap = XCreateColormap(xvar->display,xvar->root,
 				 xvar->visual,AllocNone);
 	mlx_int_rgb_conversion(xvar);
+	xvar->end_loop = 0;
 	return (xvar);
 }
 

--- a/mlx_int.h
+++ b/mlx_int.h
@@ -114,6 +114,7 @@ typedef struct	s_xvar
 	int			do_flush;
 	int			decrgb[6];
 	Atom		wm_delete_window;
+	int 		end_loop;
 }				t_xvar;
 
 

--- a/mlx_loop.c
+++ b/mlx_loop.c
@@ -28,40 +28,32 @@ static int	win_count(t_xvar *xvar)
 	return (i);
 }
 
+int			mlx_loop_end(t_xvar *xvar)
+{
+	xvar->end_loop = 1;
+	return (1);
+}
+
 int			mlx_loop(t_xvar *xvar)
 {
 	XEvent		ev;
 	t_win_list	*win;
-	int 		end_loop;
 
 	mlx_int_set_win_event_mask(xvar);
 	xvar->do_flush = 0;
-	end_loop = 0;
-	while (win_count(xvar))
+	while (win_count(xvar) && !xvar->end_loop)
 	{
-		while (!xvar->loop_hook || XPending(xvar->display))
+		while (!xvar->end_loop && (!xvar->loop_hook || XPending(xvar->display)))
 		{
 			XNextEvent(xvar->display,&ev);
 			win = xvar->win_list;
 			while (win && (win->window!=ev.xany.window))
 				win = win->next;
 			if (win && ev.type < MLX_MAX_EVENT && win->hooks[ev.type].hook)
-			{
-				end_loop = (ev.type == ClientMessage
-							&& (Atom)ev.xclient.data.l[0] == xvar->wm_delete_window)
-						   || ev.xkey.keycode == 9;
 				mlx_int_param_event[ev.type](xvar, &ev, win);
-				if (end_loop)
-					break;
-			}
 		}
-		if (!end_loop)
-		{
-			xvar->loop_hook(xvar->loop_param);
-			XSync(xvar->display, False);
-		}
-		else
-			break ;
+		xvar->loop_hook(xvar->loop_param);
+		XSync(xvar->display, False);
 	}
 	return (0);
 }


### PR DESCRIPTION
I was told that breaking mlx_loop with escape button wasn't always a standard so I made a mlx_loop_end function that can be called in any event to choose when to stop mlx_loop, so you can choose which button can stop the game loop.
For instance, it can be called mlx_hook(win_ptr, 33, 1L << 17, &mlx_loop_end, mlx_ptr); to stop it with the red cross.