### PR TITLE
Adds the possibility to use DestroyNotify event hook function

### DIFF
--- a/mlx_init.c
+++ b/mlx_init.c
@@ -38,6 +38,7 @@ void	*mlx_init()
 	xvar->loop_param = (void *)0;
 	xvar->do_flush = 1;
 	xvar->wm_delete_window = XInternAtom (xvar->display, "WM_DELETE_WINDOW", False);
+	xvar->wm_protocols = XInternAtom (xvar->display, "WM_PROTOCOLS", False);
 	mlx_int_deal_shm(xvar);
 	if (xvar->private_cmap)
 		xvar->cmap = XCreateColormap(xvar->display,xvar->root,

--- a/mlx_int.h
+++ b/mlx_int.h
@@ -114,6 +114,7 @@ typedef struct	s_xvar
 	int			do_flush;
 	int			decrgb[6];
 	Atom		wm_delete_window;
+	Atom		wm_protocols;
 	int 		end_loop;
 }				t_xvar;
 

--- a/mlx_loop.c
+++ b/mlx_loop.c
@@ -50,6 +50,8 @@ int			mlx_loop(t_xvar *xvar)
 			while (win && (win->window!=ev.xany.window))
 				win = win->next;
 
+			if (win && ev.type == ClientMessage && ev.xclient.message_type == xvar->wm_protocols && ev.xclient.data.l[0] == xvar->wm_delete_window && win->hooks[DestroyNotify].hook)
+				win->hooks[DestroyNotify].hook(win->hooks[DestroyNotify].param);
 			if (win && ev.type < MLX_MAX_EVENT && win->hooks[ev.type].hook)
 				mlx_int_param_event[ev.type](xvar, &ev, win);
 		}

--- a/mlx_loop.c
+++ b/mlx_loop.c
@@ -49,11 +49,12 @@ int			mlx_loop(t_xvar *xvar)
 			win = xvar->win_list;
 			while (win && (win->window!=ev.xany.window))
 				win = win->next;
+
 			if (win && ev.type < MLX_MAX_EVENT && win->hooks[ev.type].hook)
 				mlx_int_param_event[ev.type](xvar, &ev, win);
 		}
-		xvar->loop_hook(xvar->loop_param);
 		XSync(xvar->display, False);
+		xvar->loop_hook(xvar->loop_param);
 	}
 	return (0);
 }


### PR DESCRIPTION
**This change will not affect current projects.**

It allows for the use of the DestroyNotify hook function instead of ClientMessage hook to trigger the end of the program, similarly to older versions and to my understanding to the MacOS version too.
The issue being that ClientMessage isn't guaranteed to be of MW_DELETE_WINDOW Atom and without using libX function, the user would have no way to check whether the ClientMessage is indeed to ask for the termination of the window/program or not.
Note that the condition is pretty similar to how it was back a few months ago aside from directly using the hook rather than XDestroyWindow() as this function could lead to unintended behaviors from removing windows without clearing the win_list or warning the user.
As it only adds an extra call to a hook function, existing code not using DestroyNotify will just ignore it and in either case the ClientMessage hook will be run afterward anyway.

The pull request also includes moving back XSync before the loop hook call as it is here to make sure all events have been resolved before giving the control back to the user and having it afterward is rather pointless.