### PR TITLE
Fixed a bug that double-frees when loading a corrupted xpm file

### DIFF
--- a/mlx_xpm.c
+++ b/mlx_xpm.c
@@ -15,7 +15,7 @@ extern struct s_col_name mlx_col_name[];
 
 
 #define	RETURN	{ if (colors) free(colors); if (tab) free(tab); \
-		if (colors_direct) free(colors_direct); \
+		tab = (void *)0; if (colors_direct) free(colors_direct); \
 		if (img) {XDestroyImage(img->image); \
 				XFreePixmap(xvar->display,img->pix);free(img);} \
 		return ((void *)0);}
@@ -215,6 +215,7 @@ void	*mlx_int_parse_xpm(t_xvar *xvar,void *info,int info_size,char *(*f)())
 						colors[i].col = rgb_col; //rgb_col>=0?mlx_get_color_value(xvar,rgb_col):rgb_col;
 				}
 				free(tab);
+				tab = (void *)0;
 		}
 
 		if (!(img = mlx_new_image(xvar,width,height)))


### PR DESCRIPTION
Fixed a bug that caused double free when loading a corrupted xpm file.  
When minilibx reads bloken_kita.xpm in /map_files/error_img_bloken.cub with the cub3d tester [here](https://github.com/pettei47/42_cub3D_error_test), double free occurs.  
I fixed the double free bug by assigning NULL to the pointer variable that pointing freed address.   

Below is the run-time output before modification.  
```
~/42/42_cub3d_error_test$ ./cub3D map_files/error_img_bloken.cub 
free(): double free detected in tcache 2
Aborted (core dumped)
```
When I checked using valgrind, double free occurred in mlx_int_parse_xpm.  
```
~/42/42_cub3D_error_test$ valgrind --leak-check=full ./cub3D map_files/error_img_bloken.cub
==3931== Memcheck, a memory error detector
==3931== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3931== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==3931== Command: ./cub3D map_files/error_img_bloken.cub
==3931== 
==3931== Conditional jump or move depends on uninitialised value(s)
==3931==    at 0x11844A: mlx_int_parse_xpm (mlx_xpm.c:255)
==3931==    by 0x1186E6: mlx_xpm_file_to_image (mlx_xpm.c:324)
==3931==    by 0x1141E8: file_to_image (mlx_xpm_utils.c:21)
==3931==    by 0x114315: load_images (mlx_xpm_utils.c:45)
==3931==    by 0x111533: set_mlx (render.c:35)
==3931==    by 0x10FE6F: main (main.c:93)
==3931== 
==3931== Invalid free() / delete / delete[] / realloc()
==3931==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==3931==    by 0x1182E1: mlx_int_parse_xpm (mlx_xpm.c:230)
==3931==    by 0x1186E6: mlx_xpm_file_to_image (mlx_xpm.c:324)
==3931==    by 0x1141E8: file_to_image (mlx_xpm_utils.c:21)
==3931==    by 0x114315: load_images (mlx_xpm_utils.c:45)
==3931==    by 0x111533: set_mlx (render.c:35)
==3931==    by 0x10FE6F: main (main.c:93)
==3931==  Address 0x4db5b80 is 0 bytes inside a block of size 24 free'd
==3931==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==3931==    by 0x11813A: mlx_int_parse_xpm (mlx_xpm.c:217)
==3931==    by 0x1186E6: mlx_xpm_file_to_image (mlx_xpm.c:324)
==3931==    by 0x1141E8: file_to_image (mlx_xpm_utils.c:21)
==3931==    by 0x114315: load_images (mlx_xpm_utils.c:45)
==3931==    by 0x111533: set_mlx (render.c:35)
==3931==    by 0x10FE6F: main (main.c:93)
==3931==  Block was alloc'd at
==3931==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==3931==    by 0x1189E3: mlx_int_str_to_wordtab (mlx_int_str_to_wordtab.c:92)
==3931==    by 0x117E50: mlx_int_parse_xpm (mlx_xpm.c:190)
==3931==    by 0x1186E6: mlx_xpm_file_to_image (mlx_xpm.c:324)
==3931==    by 0x1141E8: file_to_image (mlx_xpm_utils.c:21)
==3931==    by 0x114315: load_images (mlx_xpm_utils.c:45)
==3931==    by 0x111533: set_mlx (render.c:35)
==3931==    by 0x10FE6F: main (main.c:93)
==3931== 
Error
Minilibx error.
==3931== 
==3931== HEAP SUMMARY:
==3931==     in use at exit: 0 bytes in 0 blocks
==3931==   total heap usage: 593 allocs, 594 frees, 395,258 bytes allocated
==3931== 
==3931== All heap blocks were freed -- no leaks are possible
==3931== 
==3931== Use --track-origins=yes to see where uninitialised values come from
==3931== For lists of detected and suppressed errors, rerun with: -s
==3931== ERROR SUMMARY: 23278 errors from 2 contexts (suppressed: 2 from 1)
```
For your reference, below is the environment where double free ocurred.  
- Ubuntu 20.04
- gcc (Ubuntu 9.3.0-17Ubuntu1~20.04) 9.3.0