### PR TITLE
fixing issue for mlx_xpm_to_image

### DIFF
--- a/mlx_xpm.c
+++ b/mlx_xpm.c
@@ -75,7 +75,7 @@ char	*mlx_int_static_line(char **xpm_data,int *pos,int size)
 					return ((char *)0);
 			len = len2;
 	}
-	strlcpy_is_not_posix(copy, str, len2);
+	strlcpy_is_not_posix(copy, str, len2 + 1);
 	
 	return (copy);
 }


### PR DESCRIPTION
mlx_xpm_to_image doesn't work (it doesn't read the last char of each line, so color are mess up and img miss the last pixel)
Fixed by changing the size for strlcpy in mlx_int_static_line