### PR TITLE
Fix segfault in mlx_loop

### DIFF
--- a/mlx_loop.c
+++ b/mlx_loop.c
@@ -56,7 +56,8 @@ int			mlx_loop(t_xvar *xvar)
 				mlx_int_param_event[ev.type](xvar, &ev, win);
 		}
 		XSync(xvar->display, False);
-		xvar->loop_hook(xvar->loop_param);
+		if (xvar->loop_hook)
+			xvar->loop_hook(xvar->loop_param);
 	}
 	return (0);
 }


### PR DESCRIPTION
Fix segfault in mlx_loop when calling mlx_loop_end without setting mlx_loop_hook.
Related issue #33 