### PR TITLE
Free string in mlx_string_put.c

### DIFF
--- a/mlx_string_put.c
+++ b/mlx_string_put.c
@@ -21,6 +21,7 @@ int		mlx_string_put(t_xvar *xvar,t_win_list *win,
    xgcv.foreground = mlx_int_get_good_color(xvar,color);
    XChangeGC(xvar->display,win->gc,GCForeground,&xgcv);
    XDrawString(xvar->display,win->window,win->gc,x,y,string,strlen(string));
+   free(string);
    if (xvar->do_flush)
      XFlush(xvar->display);
 }


### PR DESCRIPTION
I suggest free(string) in line 24. In project I passed ft_itoa(num) into string parameter. itoa(num) has malloc in it. As alternative to proposed free() in line 24 - stack string might be used, to prevent this memory leak.
Of course it depends if user wants to print one string on screen or wants display dynamic text. 