### PR TITLE
mlx_destroy_display leaves memory unfreed

### DIFF
--- a/mlx_destroy_display.c
+++ b/mlx_destroy_display.c
@@ -14,5 +14,6 @@
 
 int	mlx_destroy_display(t_xvar *xvar)
 {
+	free(xvar);
 	XCloseDisplay(xvar->display);
 }


### PR DESCRIPTION
`mlx_destroy_display` was added to free memory, allocated with `mlx_init`. Unfortunately, now it leaves `t_xvar *xvar` unfreed, so memory is still leaking