### PR TITLE
Remove unnecessary dependencies for Linux build of /test

### DIFF
--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -21,8 +21,7 @@ else ifeq ($(UNAME), FreeBSD)
 	CC = clang
 else
 	#Linux and others...
-	CC	= gcc
-	LFLAGS += -lbsd
+	CC = cc
 endif
 
 all: $(NAME)


### PR DESCRIPTION
There is no need for **libbsd** to link **mlx-test** on Linux.
And no need to stick to GCC, better use "default" compiler (which can be configured to clang for those who prefer clang).