### PR TITLE
mlx_xpm_file_to_image: segfault: pointer null

### DIFF
--- a/mlx_xpm.c
+++ b/mlx_xpm.c
@@ -324,8 +324,10 @@ void	*mlx_xpm_file_to_image(t_xvar *xvar,char *file,int *width,int *height)
 		mlx_int_file_get_rid_comment(ptr, size);
 		if (img = mlx_int_parse_xpm(xvar,ptr,size,mlx_int_get_line))
 		{
-				*width = img->width;
-				*height = img->height;
+				if (width)
+						*width = img->width;
+				if (height)
+						*height = img->height;
 		}
 		munmap(ptr,size);
 		close(fd);


### PR DESCRIPTION
I added conditions If the pointers were null;
like that, if we don't care about the image size, we can put 0 instead integer pointer.