### PR TITLE
Update mlx_pixel_put.3

### DIFF
--- a/man/man3/mlx_pixel_put.3
+++ b/man/man3/mlx_pixel_put.3
@@ -63,11 +63,14 @@ to create the original color. Theses three values must be set inside the
 integer to display the right color. The three least significant bytes of
 this integer are filled as shown in the picture below:
 
-.nf
-        | 0 | R | G | B |   color integer
-        +---+---+---+---+
-.fi
-
+.TS
+allbox;
+c	s	s	s	s
+r	c	c	c	c.
+Color Integer
+Interpretation	\[*a]	R	G	B
+Bit numbers	31..24	23..16	15..8	7..0
+.TE
 
 While filling the integer, make sure you avoid endian problems. Remember
 that the "blue" byte should always be the least significant one.


### PR DESCRIPTION
This file was cloned from mlx_pixel_put.1 and renamed to .3 extension.
However the original file was changed and this was not so far.
So this change is to match the current version of mlx_pixel_put.1 that now uses a table to display the RGB logic