### PR TITLE
Fixed a compilation warning in mlx_new_image.c file

### DIFF
--- a/mlx_new_image.c
+++ b/mlx_new_image.c
@@ -24,7 +24,7 @@ int	mlx_X_error;
 int	shm_att_pb(Display *d,XErrorEvent *ev)
 {
   if (ev->request_code==146 && ev->minor_code==X_ShmAttach)
-    write(2,WARN_SHM_ATTACH,strlen(WARN_SHM_ATTACH));
+    return (write(2,WARN_SHM_ATTACH,strlen(WARN_SHM_ATTACH)));
   mlx_X_error = 1;
 }
 


### PR DESCRIPTION
This pull request addresses a compilation warning in **mlx_new_image.c** related to the **shm_att_pb** function. 
The warning indicated that the return value of the write function was being ignored : **warn_unused_result**.

### Changes Made:
Previously, the code had a line where write(2, WARN_SHM_ATTACH, strlen(WARN_SHM_ATTACH)) was called without handling its return value.
Now the code properly handle the return value of the write function.
The modification ensures that the return value is returned by the **shm_att_pb** function.