### PR TITLE
Fixed uninitialized variable that would cause valgrind errors

### DIFF
--- a/mlx_int_anti_resize_win.c
+++ b/mlx_int_anti_resize_win.c
@@ -13,7 +13,7 @@
 
 int	mlx_int_anti_resize_win(t_xvar *xvar,Window win,int w,int h)
 {
-  XSizeHints    hints;
+  XSizeHints    hints = {0};
   long		toto;
   
   XGetWMNormalHints(xvar->display,win,&hints,&toto);


### PR DESCRIPTION
Changed file 'mlx_int_anti_resize_win.c' line 16 by initializing stack-allocated variable 'XSizeHints hints' with 0 values.

**Previous behavior :** 
![image](https://github.com/42Paris/minilibx-linux/assets/38769246/3a1fa8dc-1b34-4616-bd5f-7e47349ba741)

**Fixed behavior :** 
![image](https://github.com/42Paris/minilibx-linux/assets/38769246/0bfd01f5-8170-4379-abdc-3231183fca63)

Valgrind version : 
- valgrind-3.18.1

Note : The error can appear suppressed on some non-defined configuration.