### PR TITLE
Fix: handle unused-result warning during compilation

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -36,7 +36,7 @@ SRC	= mlx_init.c mlx_new_window.c mlx_pixel_put.c mlx_loop.c \
 
 OBJ_DIR = obj
 OBJ	= $(addprefix $(OBJ_DIR)/,$(SRC:%.c=%.o))
-CFLAGS	= -O3 -I$(INC)
+CFLAGS	= -O3 -I$(INC) -Wno-unused-result
 
 all	: $(NAME)
 


### PR DESCRIPTION
As students of 42, when compiling our projects, we strive to maintain a clean output free of errors or warnings. In projects that use minilibx-linux, certain warnings may appear that are beyond our control, but it is still valuable to address them for clarity and presentation. For this reason, I made a small modification by adding the -Wno-unused-result flag to the Makefile.mk.

I understand that for the development and maintenance of this library, controlling unused variables is essential. However, as a library distribution used in 42 projects, these warnings may impact the perceived quality of both the library and the students' projects that rely on it. For this reason, I believe this small contribution could be considered helpful.

Thank you very much!