### PR TITLE
mlx_new_image.c: silence unused-result warning in shm_att_pb using GC…

### DIFF
--- a/mlx_new_image.c
+++ b/mlx_new_image.c
@@ -24,7 +24,12 @@ int	mlx_X_error;
 int	shm_att_pb(Display *d,XErrorEvent *ev)
 {
   if (ev->request_code==146 && ev->minor_code==X_ShmAttach)
-    write(2,WARN_SHM_ATTACH,strlen(WARN_SHM_ATTACH));
+  {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-result"
+    write(2, WARN_SHM_ATTACH, strlen(WARN_SHM_ATTACH));
+    #pragma GCC diagnostic pop
+  }
   mlx_X_error = 1;
 }
 


### PR DESCRIPTION
change silences the warning by using GCC diagnostic pragmas.
I don't know why, but this warning was annoying me every time I was compiling minilibx on linux. 