### PR TITLE
fix(mlx): initialize XSizeHints to avoid uninitialized memory usage

### DIFF
--- a/mlx_int_anti_resize_win.c
+++ b/mlx_int_anti_resize_win.c
@@ -16,6 +16,7 @@ int	mlx_int_anti_resize_win(t_xvar *xvar,Window win,int w,int h)
   XSizeHints    hints;
   long		toto;
   
+  memset(&hints, 0, sizeof(XSizeHints));
   XGetWMNormalHints(xvar->display,win,&hints,&toto);
   hints.width = w;
   hints.height = h;


### PR DESCRIPTION
This PR fixes an uninitialized memory usage in mlx_int_anti_resize_win.

XSizeHints structure was being used without explicit initialization, leading to Valgrind warnings and potential undefined behavior.

✅ Added memset(&hints, 0, sizeof(XSizeHints)); to properly initialize the structure.
✅ Verified that Valgrind warnings are gone after the fix.

This change improves the stability and correctness of MLX window resizing behavior.