### PR TITLE
Lhabacuc write

### DIFF
--- a/mlx_new_image.c
+++ b/mlx_new_image.c
@@ -32,7 +32,7 @@ int shm_att_pb(Display *d, XErrorEvent *ev)
     return 0;
 }
 
-/*
+/* 
 **  Data malloc :  width+32 ( bitmap_pad=32 ),    *4 = *32 / 8bit
 */
 

--- a/mlx_new_image.c
+++ b/mlx_new_image.c
@@ -21,13 +21,16 @@
 
 int	mlx_X_error;
 
-int	shm_att_pb(Display *d,XErrorEvent *ev)
+int shm_att_pb(Display *d, XErrorEvent *ev)
 {
-  if (ev->request_code==146 && ev->minor_code==X_ShmAttach)
-    write(2,WARN_SHM_ATTACH,strlen(WARN_SHM_ATTACH));
-  mlx_X_error = 1;
+    if (ev->request_code == 146 && ev->minor_code == X_ShmAttach) {
+        ssize_t result = write(2, WARN_SHM_ATTACH, strlen(WARN_SHM_ATTACH));
+        if (result == -1)
+            perror("write failed");
+    }
+    mlx_X_error = 1;
+    return 0;
 }
-
 
 /*
 **  Data malloc :  width+32 ( bitmap_pad=32 ),    *4 = *32 / 8bit

--- a/mlx_new_image.c
+++ b/mlx_new_image.c
@@ -26,7 +26,7 @@ int shm_att_pb(Display *d, XErrorEvent *ev)
     if (ev->request_code == 146 && ev->minor_code == X_ShmAttach) {
         ssize_t result = write(2, WARN_SHM_ATTACH, strlen(WARN_SHM_ATTACH));
         if (result == -1)
-            perror("write failed");
+            perror("write failed!");
     }
     mlx_X_error = 1;
     return 0;

--- a/mlx_new_image.c
+++ b/mlx_new_image.c
@@ -25,13 +25,13 @@ int shm_att_pb(Display *d, XErrorEvent *ev)
 {
     if (ev->request_code == 146 && ev->minor_code == X_ShmAttach) {
         ssize_t result = write(2, WARN_SHM_ATTACH, strlen(WARN_SHM_ATTACH));
-        if (result == -1)
-            perror("write failed!");
+        if (result == -1) {
+            perror("Failed to write SHM attach warning");
+        }
     }
     mlx_X_error = 1;
     return 0;
 }
-
 /* 
 **  Data malloc :  width+32 ( bitmap_pad=32 ),    *4 = *32 / 8bit
 */


### PR DESCRIPTION
Tested on Ubuntu 22.04 with `make` and a simple MiniLibX program to confirm the warning is resolved and functionality is intact.