### PR TITLE
Update mlx_int_anti_resize_win.c

### DIFF
--- a/mlx_int_anti_resize_win.c
+++ b/mlx_int_anti_resize_win.c
@@ -15,7 +15,9 @@ int	mlx_int_anti_resize_win(t_xvar *xvar,Window win,int w,int h)
 {
   XSizeHints    hints;
   long		toto;
-  
+
+  memset(&hints, 0, sizeof(XSizeHints));
+  toto = 0;
   XGetWMNormalHints(xvar->display,win,&hints,&toto);
   hints.width = w;
   hints.height = h;


### PR DESCRIPTION
previously when using this function it would have given this kind of error:

```bash
dlesieur@dlesieur42:~/Documents/fdf/tempfdf$ valgrind --leak-check=full --track-origins=yes ./fdf test_maps/42.fdf 
==3588550== Memcheck, a memory error detector
==3588550== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==3588550== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==3588550== Command: ./fdf test_maps/42.fdf
==3588550== 
==3588550== Syscall param writev(vector[0]) points to uninitialised byte(s)
==3588550==    at 0x4BD4864: writev (writev.c:26)
==3588550==    by 0x4CCBACA: ??? (in /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0)
==3588550==    by 0x4CCBC4E: ??? (in /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0)
==3588550==    by 0x4CCCD7E: xcb_writev (in /usr/lib/x86_64-linux-gnu/libxcb.so.1.1.0)
==3588550==    by 0x48B20B8: _XSend (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==3588550==    by 0x48B7148: _XReadEvents (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==3588550==    by 0x48B752B: XWindowEvent (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==3588550==    by 0x1219A5: mlx_int_wait_first_expose (in /home/dlesieur/Documents/fdf/tempfdf/fdf)
==3588550==    by 0x1216C5: mlx_new_window (in /home/dlesieur/Documents/fdf/tempfdf/fdf)
==3588550==    by 0x10BFB9: make_fdf (fdf.c:111)
==3588550==    by 0x10BAF7: main (main.c:40)
==3588550==  Address 0x4d2a13c is 28 bytes inside a block of size 16,384 alloc'd
==3588550==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3588550==    by 0x48A142D: XOpenDisplay (in /usr/lib/x86_64-linux-gnu/libX11.so.6.4.0)
==3588550==    by 0x121476: mlx_init (in /home/dlesieur/Documents/fdf/tempfdf/fdf)
==3588550==    by 0x10BF98: make_fdf (fdf.c:108)
==3588550==    by 0x10BAF7: main (main.c:40)
==3588550==  Uninitialised value was created by a stack allocation
==3588550==    at 0x1218A0: mlx_int_anti_resize_win (in /home/dlesieur/Documents/fdf/tempfdf/fdf)
==3588550== 

```

it fixes this issue, given by the valgrind.