### PR TITLE
Fix: Valgrind error based on unitialised values

### DIFF
--- a/mlx_int_anti_resize_win.c
+++ b/mlx_int_anti_resize_win.c
@@ -16,6 +16,7 @@ int	mlx_int_anti_resize_win(t_xvar *xvar,Window win,int w,int h)
   XSizeHints    hints;
   long		toto;
   
+  memset(&hints,0,sizeof(hints));
   XGetWMNormalHints(xvar->display,win,&hints,&toto);
   hints.width = w;
   hints.height = h;

--- a/mlx_new_window.c
+++ b/mlx_new_window.c
@@ -25,6 +25,8 @@ void	*mlx_new_window(t_xvar *xvar,int size_x,int size_y,char *title)
 	XSetWindowAttributes	xswa;
 	XGCValues				xgcv;
 
+	memset(&xswa,0,sizeof(xswa));
+	memset(&xgcv,0,sizeof(xgcv));
 	xswa.background_pixel = 0;
 	xswa.border_pixel = -1;
 	xswa.colormap = xvar->cmap;


### PR DESCRIPTION
added memset in mlx_new_window.c for xswa,xgcv and in mlx_int_anti_resize_win.c for hints
<img width="961" height="555" alt="Screenshot from 2025-10-10 13-31-41" src="https://github.com/user-attachments/assets/cbd46d33-01b1-4f19-8617-e1cb613cc991" />
<img width="950" height="841" alt="Screenshot from 2025-10-10 13-34-06" src="https://github.com/user-attachments/assets/94c91aba-971b-4f62-8340-fba926e3011c" />
