### PR TITLE
fix: prevent segfault when parsing xpm with malformed header

### DIFF
--- a/mlx_xpm.c
+++ b/mlx_xpm.c
@@ -163,7 +163,9 @@ void	*mlx_int_parse_xpm(t_xvar *xvar,void *info,int info_size,char *(*f)(char *,
 		tab = 0;
 		pos = 0;
 		if (!(line = f(info,&pos,info_size)) ||
-						!(tab = mlx_int_str_to_wordtab(line)) || !(width = atoi(tab[0])) ||
+						!(tab = mlx_int_str_to_wordtab(line)) ||
+						!tab[0] || !tab[1] || !tab[2] || !tab[3] ||
+						!(width = atoi(tab[0])) ||
 						!(height = atoi(tab[1])) || !(nc = atoi(tab[2])) ||
 						!(cpp = atoi(tab[3])) )
 				RETURN;


### PR DESCRIPTION
`mlx_str_int_to_wordtab()` may return a tab with less than 4 entries if the XPM header line is malformed. All 4 entries are sent to `atoi()` without prior NULL protection, which may cause a segfault.

This fix adds NULL checks for all four required header fields (`width`, `height`, `nc`, `cpp`) before accessing them.

[My discord (Modin#6298)](https://discord.gg/HfnMEwUP)

[My intra (rapohlen)](https://profile-v3.intra.42.fr/users/rapohlen)